### PR TITLE
fix: resolve rustdoc warnings

### DIFF
--- a/crates/kernels/dsl/src/parser/expr.rs
+++ b/crates/kernels/dsl/src/parser/expr.rs
@@ -59,7 +59,7 @@ pub fn expr<'src>() -> impl Parser<'src, &'src str, Expr, Ex<'src>> + Clone {
     spanned_expr_inner().map(|spanned| spanned.node)
 }
 
-/// Internal spanned expression parser - produces Spanned<Expr> with proper spans throughout
+/// Internal spanned expression parser - produces `Spanned<Expr>` with proper spans throughout
 fn spanned_expr_inner<'src>() -> impl Parser<'src, &'src str, Spanned<Expr>, Ex<'src>> + Clone {
     recursive(|expr| {
         // Box the recursive expr (which returns Spanned<Expr>) to prevent type explosion

--- a/crates/kernels/dsl/src/parser/primitives.rs
+++ b/crates/kernels/dsl/src/parser/primitives.rs
@@ -145,7 +145,7 @@ pub fn literal<'src>(
     choice((number(), string_lit().map(Literal::String)))
 }
 
-/// Unit in angle brackets: <K>, <W/m²>
+/// Unit in angle brackets: `<K>`, `<W/m²>`
 pub fn unit<'src>() -> impl Parser<'src, &'src str, String, extra::Err<ParseError<'src>>> + Clone {
     none_of(">")
         .repeated()

--- a/crates/kernels/ir/src/interpret/mod.rs
+++ b/crates/kernels/ir/src/interpret/mod.rs
@@ -25,7 +25,7 @@
 //! # Execution Contexts
 //!
 //! Each closure type has a corresponding context struct that implements
-//! [`ExecutionContext`] for the VM. These contexts provide access to:
+//! `ExecutionContext` for the VM. These contexts provide access to:
 //!
 //! - Previous signal value (`prev`)
 //! - Current time step (`dt`)


### PR DESCRIPTION
## Summary
Fix 3 rustdoc warnings that were causing `cargo doc` to emit warnings.

## Changes
- Escape angle brackets in doc comments (`<Expr>` → `` `Spanned<Expr>` ``)
- Escape unit examples (`<K>` → `` `<K>` ``)
- Use backticks instead of link syntax for `ExecutionContext`

## Test plan
- [x] `cargo doc --no-deps --document-private-items` passes without warnings

Closes #13