### PR TITLE
feat(chronicles): implement chronicle execution in DAG and runtime

### DIFF
--- a/crates/kernels/runtime/src/dag.rs
+++ b/crates/kernels/runtime/src/dag.rs
@@ -88,6 +88,15 @@ pub enum NodeKind {
         /// Index into the fracture detector table.
         fracture_idx: usize,
     },
+    /// Observe signals and conditionally emit chronicle events.
+    ///
+    /// Chronicles are observer-only constructs that execute in the Measure phase.
+    /// They read resolved signals and emit events for logging and analytics.
+    /// Removing all chronicles must not change simulation results.
+    ChronicleObserve {
+        /// Index into the chronicle handler table.
+        chronicle_idx: usize,
+    },
     /// Execute a lane kernel for member signal resolution (L1/L2/L3).
     ///
     /// This is the two-level execution model where a DAG node can expand

--- a/crates/kernels/runtime/src/executor/context.rs
+++ b/crates/kernels/runtime/src/executor/context.rs
@@ -75,3 +75,14 @@ pub struct AssertContext<'a> {
     /// Time step
     pub dt: Dt,
 }
+
+/// Context available to chronicle handlers (Measure phase)
+///
+/// Chronicles are observer-only constructs that read resolved signals
+/// and emit events. They cannot affect causality.
+pub struct ChronicleContext<'a> {
+    /// Access to signals (current tick values, post-resolve)
+    pub signals: &'a SignalStorage,
+    /// Time step
+    pub dt: Dt,
+}

--- a/crates/kernels/runtime/src/executor/mod.rs
+++ b/crates/kernels/runtime/src/executor/mod.rs
@@ -20,7 +20,7 @@ use tracing::{error, info, instrument, trace};
 
 use crate::dag::DagSet;
 use crate::error::{Error, Result};
-use crate::storage::{FieldBuffer, FieldSample, FractureQueue, InputChannels, SignalStorage};
+use crate::storage::{EmittedEventRecord, EventBuffer, FieldBuffer, FieldSample, FractureQueue, InputChannels, SignalStorage};
 use crate::types::{
     Dt, EraId, FieldId, SignalId, StratumId, StratumState, TickContext, Value, WarmupConfig,
     WarmupResult,
@@ -29,7 +29,7 @@ use crate::types::{
 // Re-export public types
 pub use assertions::{AssertionChecker, AssertionFn, AssertionSeverity, SignalAssertion};
 pub use context::{
-    AssertContext, CollectContext, FractureContext, ImpulseContext, MeasureContext,
+    AssertContext, ChronicleContext, CollectContext, FractureContext, ImpulseContext, MeasureContext,
     ResolveContext, WarmupContext,
 };
 pub use member_executor::{
@@ -45,7 +45,7 @@ pub use kernel_registry::LaneKernelRegistry;
 pub use l1_kernels::{ScalarKernelFn, ScalarL1Kernel, Vec3KernelFn, Vec3L1Kernel};
 pub use lane_kernel::{LaneKernel, LaneKernelError, LaneKernelResult};
 pub use lowering_strategy::{LoweringHeuristics, LoweringStrategy};
-pub use phases::{CollectFn, FractureFn, FractureParallelConfig, ImpulseFn, MeasureFn, MeasureParallelConfig, PhaseExecutor, ResolverFn};
+pub use phases::{ChronicleFn, CollectFn, EmittedEvent, FractureFn, FractureParallelConfig, ImpulseFn, MeasureFn, MeasureParallelConfig, PhaseExecutor, ResolverFn};
 pub use warmup::{RegisteredWarmup, WarmupExecutor, WarmupFn};
 
 /// Function that evaluates era transition conditions
@@ -69,6 +69,8 @@ pub struct Runtime {
     input_channels: InputChannels,
     /// Field buffer for Measure phase
     field_buffer: FieldBuffer,
+    /// Event buffer for chronicle events
+    event_buffer: EventBuffer,
     /// Fracture outputs queued for next tick
     fracture_queue: FractureQueue,
     /// Current tick number
@@ -97,6 +99,7 @@ impl Runtime {
             signals: SignalStorage::default(),
             input_channels: InputChannels::default(),
             field_buffer: FieldBuffer::default(),
+            event_buffer: EventBuffer::default(),
             fracture_queue: FractureQueue::default(),
             tick: 0,
             current_era: initial_era,
@@ -127,6 +130,11 @@ impl Runtime {
     /// Register a measure operator, returns its index
     pub fn register_measure_op(&mut self, op: MeasureFn) -> usize {
         self.phase_executor.register_measure_op(op)
+    }
+
+    /// Register a chronicle handler, returns its index
+    pub fn register_chronicle(&mut self, handler: ChronicleFn) -> usize {
+        self.phase_executor.register_chronicle(handler)
     }
 
     /// Register an impulse handler, returns its index
@@ -186,6 +194,16 @@ impl Runtime {
     /// Get access to the field buffer (for observer consumption)
     pub fn field_buffer(&self) -> &FieldBuffer {
         &self.field_buffer
+    }
+
+    /// Get access to the event buffer (for observer consumption)
+    pub fn event_buffer(&self) -> &EventBuffer {
+        &self.event_buffer
+    }
+
+    /// Drain the event buffer (for observer consumption)
+    pub fn drain_events(&mut self) -> Vec<EmittedEventRecord> {
+        self.event_buffer.drain()
     }
 
     /// Get current tick context (tick, dt, era)
@@ -294,6 +312,17 @@ impl Runtime {
             &self.dags,
             &self.signals,
             &mut self.field_buffer,
+        )?;
+
+        // Phase 5 continued: Chronicle observation (Measure phase)
+        self.phase_executor.execute_chronicles(
+            &self.current_era,
+            self.tick,
+            dt,
+            &strata_states,
+            &self.dags,
+            &self.signals,
+            &mut self.event_buffer,
         )?;
 
         // Post-tick: check era transitions
@@ -1180,5 +1209,178 @@ mod tests {
         assert_eq!(runtime.get_signal(&signal_a), Some(&Value::Scalar(10.0)));
         assert_eq!(runtime.get_signal(&signal_b), Some(&Value::Scalar(20.0)));
         assert_eq!(runtime.get_signal(&signal_c), Some(&Value::Scalar(40.0)));
+    }
+
+    #[test]
+    fn test_chronicle_event_emission() {
+        let era_id: EraId = "test".into();
+        let stratum_id: StratumId = "default".into();
+        let signal_id: SignalId = "temperature".into();
+
+        // Build DAG for Resolve phase
+        let mut resolve_builder = DagBuilder::new(Phase::Resolve, stratum_id.clone());
+        resolve_builder.add_node(DagNode {
+            id: NodeId("temp_resolve".to_string()),
+            reads: HashSet::new(),
+            writes: Some(signal_id.clone()),
+            kind: NodeKind::SignalResolve {
+                signal: signal_id.clone(),
+                resolver_idx: 0,
+            },
+        });
+        let resolve_dag = resolve_builder.build().unwrap();
+
+        // Build DAG for Measure phase with chronicle
+        let mut measure_builder = DagBuilder::new(Phase::Measure, stratum_id.clone());
+        measure_builder.add_node(DagNode {
+            id: NodeId("temp_chronicle".to_string()),
+            reads: [signal_id.clone()].into_iter().collect(),
+            writes: None,
+            kind: NodeKind::ChronicleObserve { chronicle_idx: 0 },
+        });
+        let measure_dag = measure_builder.build().unwrap();
+
+        let mut era_dags = EraDags::default();
+        era_dags.insert(resolve_dag);
+        era_dags.insert(measure_dag);
+
+        let mut dags = DagSet::default();
+        dags.insert_era(era_id.clone(), era_dags);
+
+        let mut strata = IndexMap::new();
+        strata.insert(stratum_id, StratumState::Active);
+        let era_config = EraConfig {
+            dt: Dt(1.0),
+            strata,
+            transition: None,
+        };
+
+        let mut eras = IndexMap::new();
+        eras.insert(era_id.clone(), era_config);
+
+        let mut runtime = Runtime::new(era_id, eras, dags);
+
+        // Register resolver: temperature increments by 10 each tick
+        runtime.register_resolver(Box::new(|ctx| {
+            let prev = ctx.prev.as_scalar().unwrap_or(0.0);
+            Value::Scalar(prev + 10.0)
+        }));
+
+        // Register chronicle: emit event when temperature > 100
+        let signal_id_clone = signal_id.clone();
+        runtime.register_chronicle(Box::new(move |ctx| {
+            let temp = ctx.signals.get(&signal_id_clone).unwrap().as_scalar().unwrap();
+            if temp > 100.0 {
+                vec![EmittedEvent {
+                    name: "high_temperature".to_string(),
+                    fields: vec![("temp".to_string(), Value::Scalar(temp))],
+                }]
+            } else {
+                vec![]
+            }
+        }));
+
+        runtime.init_signal(signal_id.clone(), Value::Scalar(100.0));
+
+        // Tick 1: temp = 110, should emit event
+        runtime.execute_tick().unwrap();
+        assert_eq!(runtime.get_signal(&signal_id), Some(&Value::Scalar(110.0)));
+
+        // Check event buffer
+        assert!(!runtime.event_buffer().is_empty());
+        assert_eq!(runtime.event_buffer().len(), 1);
+
+        let events = runtime.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name, "high_temperature");
+        assert_eq!(events[0].fields.len(), 1);
+        assert_eq!(events[0].fields[0].0, "temp");
+        assert_eq!(events[0].fields[0].1.as_scalar(), Some(110.0));
+
+        // After drain, buffer should be empty
+        assert!(runtime.event_buffer().is_empty());
+
+        // Tick 2: temp = 120, should emit another event
+        runtime.execute_tick().unwrap();
+        assert_eq!(runtime.event_buffer().len(), 1);
+    }
+
+    #[test]
+    fn test_chronicle_no_emission_when_condition_false() {
+        let era_id: EraId = "test".into();
+        let stratum_id: StratumId = "default".into();
+        let signal_id: SignalId = "pressure".into();
+
+        // Build DAG for Resolve phase
+        let mut resolve_builder = DagBuilder::new(Phase::Resolve, stratum_id.clone());
+        resolve_builder.add_node(DagNode {
+            id: NodeId("pressure_resolve".to_string()),
+            reads: HashSet::new(),
+            writes: Some(signal_id.clone()),
+            kind: NodeKind::SignalResolve {
+                signal: signal_id.clone(),
+                resolver_idx: 0,
+            },
+        });
+        let resolve_dag = resolve_builder.build().unwrap();
+
+        // Build DAG for Measure phase with chronicle
+        let mut measure_builder = DagBuilder::new(Phase::Measure, stratum_id.clone());
+        measure_builder.add_node(DagNode {
+            id: NodeId("pressure_chronicle".to_string()),
+            reads: [signal_id.clone()].into_iter().collect(),
+            writes: None,
+            kind: NodeKind::ChronicleObserve { chronicle_idx: 0 },
+        });
+        let measure_dag = measure_builder.build().unwrap();
+
+        let mut era_dags = EraDags::default();
+        era_dags.insert(resolve_dag);
+        era_dags.insert(measure_dag);
+
+        let mut dags = DagSet::default();
+        dags.insert_era(era_id.clone(), era_dags);
+
+        let mut strata = IndexMap::new();
+        strata.insert(stratum_id, StratumState::Active);
+        let era_config = EraConfig {
+            dt: Dt(1.0),
+            strata,
+            transition: None,
+        };
+
+        let mut eras = IndexMap::new();
+        eras.insert(era_id.clone(), era_config);
+
+        let mut runtime = Runtime::new(era_id, eras, dags);
+
+        // Register resolver: pressure stays constant at 50
+        runtime.register_resolver(Box::new(|_ctx| Value::Scalar(50.0)));
+
+        // Register chronicle: emit event only when pressure > 100 (never true)
+        let signal_id_clone = signal_id.clone();
+        runtime.register_chronicle(Box::new(move |ctx| {
+            let pressure = ctx.signals.get(&signal_id_clone).unwrap().as_scalar().unwrap();
+            if pressure > 100.0 {
+                vec![EmittedEvent {
+                    name: "high_pressure".to_string(),
+                    fields: vec![],
+                }]
+            } else {
+                vec![]
+            }
+        }));
+
+        runtime.init_signal(signal_id.clone(), Value::Scalar(0.0));
+
+        // Execute ticks - no events should be emitted
+        runtime.execute_tick().unwrap();
+        assert!(runtime.event_buffer().is_empty());
+
+        runtime.execute_tick().unwrap();
+        assert!(runtime.event_buffer().is_empty());
+
+        runtime.execute_tick().unwrap();
+        assert!(runtime.event_buffer().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add `NodeKind::ChronicleObserve` to DAG for scheduling chronicle execution
- Add `ChronicleContext` for chronicle handlers to access signals and dt
- Add `ChronicleFn` type and `execute_chronicles` to `PhaseExecutor`
- Add `EventBuffer` and `EmittedEvent` types for chronicle output
- Integrate chronicles into `Runtime` with `register_chronicle()` method
- Wire up chronicle compilation in IR-to-DAG builder
- Add unit tests for chronicle event emission

## Files Changed
- `crates/kernels/ir/src/compile.rs` - Chronicle index tracking and DAG node creation
- `crates/kernels/runtime/src/dag.rs` - `NodeKind::ChronicleObserve` variant
- `crates/kernels/runtime/src/executor/context.rs` - `ChronicleContext`
- `crates/kernels/runtime/src/executor/mod.rs` - Runtime integration and tests
- `crates/kernels/runtime/src/executor/phases.rs` - `ChronicleFn` and execution
- `crates/kernels/runtime/src/storage.rs` - `EventBuffer` and `EmittedEvent`

## Test plan
- [x] All 205 runtime tests pass
- [x] All workspace tests pass (574+ tests)
- [x] Chronicle event emission test verifies events are emitted when conditions met
- [x] Chronicle no-emission test verifies no events when conditions not met

Closes #58